### PR TITLE
Clarify the framework DAO role

### DIFF
--- a/docs/core/01-how-it-works/02-the-dao-framework/index.md
+++ b/docs/core/01-how-it-works/02-the-dao-framework/index.md
@@ -17,12 +17,8 @@ The AragonOS DAO Framework provides **infrastructure-related contracts** for the
 </div>
 
 Together, the core and infrastructure related contracts constitute the **code layer** of our aragonOS DAO framework that is built on top of external dependencies, most notably the [OpenZepplin contracts](https://www.openzeppelin.com/contracts).
-To govern the framework infrastructure, a **Framework DAO** exists to:
-
-- control the permissions of and between the infrastructure related contracts to:
-  - upgrade them
-  - allow them to register ENS names for DAOs and plugins on the `dao.eth` and `dao-plugin.eth`, respectively
-- verify plugin submissions to Aragon App
+To govern the framework infrastructure, a **Framework DAO** exists.
+The Framework DAO controls the permissions of and between the infrastructure-related contracts required to configure and maintain them as well as to replace or upgrade them.
 
 This Framework DAO constitutes the **governance layer** of the aragonOS DAO Framework.
 


### PR DESCRIPTION
This PR modifies the text explaining the role of the framework DAO. The goal is to include fewer things that are undecided yet.